### PR TITLE
fix(cmd): command with path windows/unix

### DIFF
--- a/server/routes/stack.js
+++ b/server/routes/stack.js
@@ -95,7 +95,7 @@ function launch() {
 function launchService(microservice) {
   microservice.spawnOptions = microservice.spawnOptions || {}
   microservice.spawnOptions.shell = true
-  if (microservice.spawnOptions.cwd) {
+  if (microservice.spawnOptions.cwd && microservice.spawnCmd.match(/\/|\\/g)) {
     microservice.spawnCmd = path.resolve(microservice.spawnOptions.cwd, microservice.spawnCmd)
   }
   SpawnStore[microservice.label] = spawn(microservice.spawnCmd, microservice.spawnArgs || [], microservice.spawnOptions)


### PR DESCRIPTION
Check only the cwd is not safe, you must also check that the command is a path 

Ex: SpawnCmd: npm and cwd : ./