### PR TITLE
fix(npm): fix crash on windows

### DIFF
--- a/server/models/Npm.js
+++ b/server/models/Npm.js
@@ -82,7 +82,7 @@ Npm.prototype.run = async function (command) {
     const args = defaultCommand[command]
       ? defaultCommand[command]
       : ['run', ...cmd]
-    return spawn('npm', args, { cwd: path })
+    return spawn('npm', args, { cwd: path, env: Object.assign({}, process.env), shell: true })
   }
 }
 


### PR DESCRIPTION
Shell options was not passed to nodejs spawn. I have link all process.env to spawn too.  